### PR TITLE
Make FCModel.py working on CUDA

### DIFF
--- a/models/FCModel.py
+++ b/models/FCModel.py
@@ -59,10 +59,10 @@ class FCModel(CaptionModel):
 
         self.ss_prob = 0.0 # Schedule sampling probability
 
-        self.img_embed = nn.Linear(self.fc_feat_size, self.input_encoding_size)
-        self.core = LSTMCore(opt)
-        self.embed = nn.Embedding(self.vocab_size + 1, self.input_encoding_size)
-        self.logit = nn.Linear(self.rnn_size, self.vocab_size + 1)
+        self.img_embed = nn.Linear(self.fc_feat_size, self.input_encoding_size).to(device)
+        self.core = LSTMCore(opt).to(device)
+        self.embed = nn.Embedding(self.vocab_size + 1, self.input_encoding_size).to(device)
+        self.logit = nn.Linear(self.rnn_size, self.vocab_size + 1).to(device)
 
         self.init_weights()
 


### PR DESCRIPTION
I tried to run `python eval.py --model ./data/FC/fc-model.pth --infos_path ./data/FC/fc-infos.pkl --image_folder ./data`(as said in the book on page 34) with different versions of PyTorch CUDA-enabled builds but all my attempts failed with the following errors. But if I use CPU-only PyTorch builds, then everything works as expected
```
(dl-with-pt) C:\Users\pavel\dev\ImageCaptioning.pytorch>python eval.py --model ./data/FC/fc-model.pth --infos_path ./data/FC/fc-infos.pkl --image_folder ./data
DataLoaderRaw loading images from folder:  ./data
0
listing all images in directory ./data
DataLoaderRaw found  1  images
C:\Users\pavel\.conda\envs\dl-with-pt\lib\site-packages\torch\nn\functional.py:1625: UserWarning: nn.functional.sigmoid is deprecated. Use torch.sigmoid instead.
  warnings.warn("nn.functional.sigmoid is deprecated. Use torch.sigmoid instead.")
C:\Users\pavel\.conda\envs\dl-with-pt\lib\site-packages\torch\nn\functional.py:1614: UserWarning: nn.functional.tanh is deprecated. Use torch.tanh instead.
  warnings.warn("nn.functional.tanh is deprecated. Use torch.tanh instead.")
C:\Users\pavel\dev\ImageCaptioning.pytorch\models\FCModel.py:149: UserWarning: Implicit dimension choice for log_softmax has been deprecated. Change the call to include dim=X as an argument.
  logprobs = F.log_softmax(self.logit(output))
Traceback (most recent call last):
  File "eval.py", line 132, in <module>
    loss, split_predictions, lang_stats = eval_utils.eval_split(
  File "C:\Users\pavel\dev\ImageCaptioning.pytorch\eval_utils.py", line 106, in eval_split
    seq, _ = model.sample(fc_feats, att_feats, eval_kwargs)
  File "C:\Users\pavel\dev\ImageCaptioning.pytorch\models\FCModel.py", line 162, in sample
    return self.sample_beam(fc_feats, att_feats, opt)
  File "C:\Users\pavel\dev\ImageCaptioning.pytorch\models\FCModel.py", line 144, in sample_beam
    xt = self.embed(Variable(it, requires_grad=False))
  File "C:\Users\pavel\.conda\envs\dl-with-pt\lib\site-packages\torch\nn\modules\module.py", line 722, in _call_impl
    result = self.forward(*input, **kwargs)
  File "C:\Users\pavel\.conda\envs\dl-with-pt\lib\site-packages\torch\nn\modules\sparse.py", line 124, in forward
    return F.embedding(
  File "C:\Users\pavel\.conda\envs\dl-with-pt\lib\site-packages\torch\nn\functional.py", line 1814, in embedding
    return torch.embedding(weight, input, padding_idx, scale_grad_by_freq, sparse)
RuntimeError: Expected object of device type cuda but got device type cpu for argument #1 'self' in call to _th_index_select
```
or
```
(dl-with-pt) C:\Users\pavel\dev\ImageCaptioning.pytorch>python eval.py --model ./data/FC/fc-model.pth --infos_path ./data/FC/fc-infos.pkl --image_folder ./data
DataLoaderRaw loading images from folder:  ./data
0
listing all images in directory ./data
DataLoaderRaw found  1  images
C:\Users\pavel\.conda\envs\dl-with-pt\lib\site-packages\torch\nn\functional.py:1625: UserWarning: nn.functional.sigmoid is deprecated. Use torch.sigmoid instead.
  warnings.warn("nn.functional.sigmoid is deprecated. Use torch.sigmoid instead.")
C:\Users\pavel\.conda\envs\dl-with-pt\lib\site-packages\torch\nn\functional.py:1614: UserWarning: nn.functional.tanh is deprecated. Use torch.tanh instead.
  warnings.warn("nn.functional.tanh is deprecated. Use torch.tanh instead.")
C:\Users\pavel\dev\ImageCaptioning.pytorch\models\FCModel.py:149: UserWarning: Implicit dimension choice for log_softmax has been deprecated. Change the call to include dim=X as an argument.
  logprobs = F.log_softmax(self.logit(output))
Traceback (most recent call last):
  File "eval.py", line 132, in <module>
    loss, split_predictions, lang_stats = eval_utils.eval_split(
  File "C:\Users\pavel\dev\ImageCaptioning.pytorch\eval_utils.py", line 106, in eval_split
    seq, _ = model.sample(fc_feats, att_feats, eval_kwargs)
  File "C:\Users\pavel\dev\ImageCaptioning.pytorch\models\FCModel.py", line 162, in sample
    return self.sample_beam(fc_feats, att_feats, opt)
  File "C:\Users\pavel\dev\ImageCaptioning.pytorch\models\FCModel.py", line 143, in sample_beam
    it = fc_feats.data.new(beam_size).long().zero_()
RuntimeError: CUDA error: unknown error
```
I debugged the code and looks like FCModel layers were forgotten to be moved to the device.