### PR TITLE
added check for GPU into eval.py

### DIFF
--- a/eval.py
+++ b/eval.py
@@ -109,9 +109,13 @@ for k in vars(infos['opt']).keys():
 
 vocab = infos['vocab'] # ix -> word mapping
 
+#check for GPU
+device = 'cuda' if torch.cuda.is_available() else 'cpu'
+
 # Setup the model
 model = models.setup(opt)
 model.load_state_dict(torch.load(opt.model, map_location=torch.device(device)))
+model.to(device=device)
 model.eval()
 crit = utils.LanguageModelCriterion()
 


### PR DESCRIPTION
When running eval.py on Cuda 11 / pytorch 1.9 , ran into following error

`RuntimeError: Tensor for 'out' is on CPU, Tensor for argument #1 'self' is on CPU, but expected them to be on GPU (while checking arguments for addmm)`

Added similar check as in the model files to put the model to the device (gpu or cpu)